### PR TITLE
Use phoenix sp credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,0 @@
-IDP_SP_URL: 'http://localhost:3000'
-
-# IDP with basic authentication
-IDP_USER: 'USERNAME'
-IDP_PASSWORD: 'PASSWORD'
-
-ACR_VALUES: 'http://idmanagement.gov/ns/assurance/loa/1'
-REDIRECT_URI: 'http://localhost:9292/'
-CLIENT_ID: 'urn:gov:gsa:openidconnect:sp:sinatra'

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -49,8 +49,6 @@ config :phoenix, :stacktrace_depth, 20
 
 config :identity_oidc, :oidc_config,
   idp_sp_url: "http://localhost:3000",
-  idp_user: "USERNAME",
-  idp_password: "PASSWORD",
   acr_values: "http://idmanagement.gov/ns/assurance/loa/1",
   redirect_uri: "http://localhost:4000/",
   client_id: "urn:gov:gsa:openidconnect:sp:phoenix"


### PR DESCRIPTION
**WHY**:
Because all the cool example SPs
have their own credentials

Also removed basic auth credentials since they are no longer used.